### PR TITLE
Feat/Match fields with native bitcoin-etl exports

### DIFF
--- a/bitcoinetl/cli/export_all.py
+++ b/bitcoinetl/cli/export_all.py
@@ -25,7 +25,7 @@ import click
 import re
 
 from datetime import datetime, timedelta
-from bitcoinetl.enumeration.chain import Chain, CoinPriceType
+from bitcoinetl.enumeration.chain import Chain
 from bitcoinetl.jobs.export_all import export_all as do_export_all
 from bitcoinetl.service.btc_block_range_service import BtcBlockRangeService
 from bitcoinetl.rpc.bitcoin_rpc import BitcoinRpc

--- a/bitcoinetl/cli/export_blocks_and_transactions.py
+++ b/bitcoinetl/cli/export_blocks_and_transactions.py
@@ -23,6 +23,7 @@
 
 import click
 
+from bitcoinetl.enumeration.chain import Chain
 from bitcoinetl.jobs.export_blocks_job import ExportBlocksJob
 from bitcoinetl.jobs.exporters.blocks_and_transactions_item_exporter import blocks_and_transactions_item_exporter
 from bitcoinetl.rpc.bitcoin_rpc import BitcoinRpc

--- a/bitcoinetl/cli/export_blocks_and_transactions.py
+++ b/bitcoinetl/cli/export_blocks_and_transactions.py
@@ -23,7 +23,6 @@
 
 import click
 
-from bitcoinetl.enumeration.chain import Chain, CoinPriceType
 from bitcoinetl.jobs.export_blocks_job import ExportBlocksJob
 from bitcoinetl.jobs.exporters.blocks_and_transactions_item_exporter import blocks_and_transactions_item_exporter
 from bitcoinetl.rpc.bitcoin_rpc import BitcoinRpc

--- a/bitcoinetl/domain/block.py
+++ b/bitcoinetl/domain/block.py
@@ -29,7 +29,6 @@ class BtcBlock(object):
         self.hash = None
         self.size = None
         self.stripped_size = None
-        self.weight = None
         self.number = None
         self.version = None
         self.merkle_root = None

--- a/bitcoinetl/domain/transaction.py
+++ b/bitcoinetl/domain/transaction.py
@@ -34,7 +34,6 @@ class BtcTransaction(object):
         self.block_hash = None
         self.block_timestamp = None
         self.is_coinbase = False
-        self.index = None
         self.fee= None
 
         self.inputs = []
@@ -45,8 +44,6 @@ class BtcTransaction(object):
         self.value_balance = 0
 
         # New fields
-        self.transaction_id = None
-        self.weight = None
         self.input_count = None
         self.input_value = None
         self.output_count = None

--- a/bitcoinetl/domain/transaction.py
+++ b/bitcoinetl/domain/transaction.py
@@ -35,6 +35,7 @@ class BtcTransaction(object):
         self.block_timestamp = None
         self.is_coinbase = False
         self.index = None
+        self.fee= None
 
         self.inputs = []
         self.outputs = []

--- a/bitcoinetl/domain/transaction.py
+++ b/bitcoinetl/domain/transaction.py
@@ -44,6 +44,7 @@ class BtcTransaction(object):
         self.value_balance = 0
 
         # New fields
+        self.weight = None
         self.input_count = None
         self.input_value = None
         self.output_count = None

--- a/bitcoinetl/domain/transaction.py
+++ b/bitcoinetl/domain/transaction.py
@@ -44,7 +44,6 @@ class BtcTransaction(object):
         self.value_balance = 0
 
         # New fields
-        self.weight = None
         self.input_count = None
         self.input_value = None
         self.output_count = None

--- a/bitcoinetl/domain/transaction_input.py
+++ b/bitcoinetl/domain/transaction_input.py
@@ -23,12 +23,9 @@
 
 class BtcTransactionInput(object):
     def __init__(self):
-        self.create_transaction_id = None
-        self.create_output_index = None
-
-        self.spending_transaction_id = None
         self.index = None
-
+        self.spent_transaction_hash = None
+        self.spent_output_index = None
         self.script_asm = None
         self.script_hex = None
         self.coinbase_param = None
@@ -40,4 +37,4 @@ class BtcTransactionInput(object):
         self.value = None
 
     def is_coinbase(self):
-        return self.coinbase_param is not None or self.create_transaction_id is None
+        return self.coinbase_param is not None or self.spent_transaction_hash is None

--- a/bitcoinetl/domain/transaction_output.py
+++ b/bitcoinetl/domain/transaction_output.py
@@ -31,7 +31,3 @@ class BtcTransactionOutput(object):
 
         self.addresses = []
         self.value = None
-        self.witness = []
-
-        self.create_transaction_id = None
-        self.spending_transaction_id = None

--- a/bitcoinetl/enumeration/chain.py
+++ b/bitcoinetl/enumeration/chain.py
@@ -27,9 +27,3 @@ class Chain:
         }
         return symbols.get(chain, None)
 
-
-class CoinPriceType:
-
-    empty = 0
-    daily = 1
-    hourly = 2

--- a/bitcoinetl/jobs/enrich_transactions.py
+++ b/bitcoinetl/jobs/enrich_transactions.py
@@ -80,7 +80,7 @@ class EnrichTransactionsJob(BaseJob):
         transaction_hashes = set(transaction_hashes)
         if len(transaction_hashes) > 0:
             transactions = self.btc_service.get_transactions_by_hashes(transaction_hashes)
-            return {transaction.transaction_id: transaction for transaction in transactions}
+            return {transaction.hash: transaction for transaction in transactions}
         else:
             return {}
 

--- a/bitcoinetl/jobs/export_blocks_job.py
+++ b/bitcoinetl/jobs/export_blocks_job.py
@@ -27,7 +27,6 @@ from bitcoinetl.service.btc_service import BtcService
 from blockchainetl.executors.batch_work_executor import BatchWorkExecutor
 from blockchainetl.jobs.base_job import BaseJob
 from blockchainetl.utils import validate_range
-from bitcoinetl.enumeration.chain import CoinPriceType
 
 
 # Exports blocks and transactions

--- a/bitcoinetl/jobs/exporters/blocks_and_transactions_item_exporter.py
+++ b/bitcoinetl/jobs/exporters/blocks_and_transactions_item_exporter.py
@@ -58,6 +58,7 @@ TRANSACTION_FIELDS_TO_EXPORT = [
     'lock_time',
     'size',
     'virtual_size',
+    'weight',
     'version',
     'index',
     'input_count',

--- a/bitcoinetl/jobs/exporters/blocks_and_transactions_item_exporter.py
+++ b/bitcoinetl/jobs/exporters/blocks_and_transactions_item_exporter.py
@@ -66,6 +66,7 @@ TRANSACTION_FIELDS_TO_EXPORT = [
     'output_count',
     'input_value',
     'output_value',
+    'fee',
     'inputs',
     'outputs',
 ]

--- a/bitcoinetl/jobs/exporters/blocks_and_transactions_item_exporter.py
+++ b/bitcoinetl/jobs/exporters/blocks_and_transactions_item_exporter.py
@@ -50,7 +50,6 @@ BLOCK_FIELDS_TO_EXPORT = [
 
 
 TRANSACTION_FIELDS_TO_EXPORT = [
-    'transaction_id',
     'hash',
     'block_number',
     'block_hash',
@@ -59,7 +58,6 @@ TRANSACTION_FIELDS_TO_EXPORT = [
     'lock_time',
     'size',
     'virtual_size',
-    'weight',
     'version',
     'index',
     'input_count',

--- a/bitcoinetl/mappers/block_mapper.py
+++ b/bitcoinetl/mappers/block_mapper.py
@@ -52,7 +52,7 @@ class BtcBlockMapper(object):
                 block.transactions = [
                     self.transaction_mapper.json_dict_to_transaction(tx, block, idx) for idx, tx in enumerate(raw_transactions)
                 ]
-                block.transaction_ids = [tx.transaction_id for tx in block.transactions]
+                block.transaction_ids = [tx.hash for tx in block.transactions]
             else:
                 # Transaction hashes
                 block.transactions = raw_transactions

--- a/bitcoinetl/mappers/transaction_input_mapper.py
+++ b/bitcoinetl/mappers/transaction_input_mapper.py
@@ -25,28 +25,24 @@ from bitcoinetl.domain.transaction_input import BtcTransactionInput
 
 
 class BtcTransactionInputMapper(object):
-    def vin_to_inputs(self, vin, spending_transaction_id=None):
+    def vin_to_inputs(self, vin):
         inputs = []
         index = 0
         for item in (vin or []):
-            input = self.json_dict_to_input(json_dict=item, spending_transaction_id=spending_transaction_id)
+            input = self.json_dict_to_input(item)
             input.index = index
             index = index + 1
             inputs.append(input)
 
         return inputs
 
-    def json_dict_to_input(self, json_dict, spending_transaction_id=None):
+    def json_dict_to_input(self, json_dict):
         input = BtcTransactionInput()
 
-        input.create_transaction_id = json_dict.get('txid')
-        input.create_output_index = json_dict.get('vout')
-
-        input.spending_transaction_id = spending_transaction_id
-
+        input.spent_transaction_hash = json_dict.get('txid')
+        input.spent_output_index = json_dict.get('vout')
         input.coinbase_param = json_dict.get('coinbase')
         input.sequence = json_dict.get('sequence')
-
         if 'scriptSig' in json_dict:
             input.script_asm = '' #(json_dict.get('scriptSig')).get('asm')
             input.script_hex = '' #(json_dict.get('scriptSig')).get('hex')
@@ -58,14 +54,11 @@ class BtcTransactionInputMapper(object):
         for input in inputs:
             item = {
                 'index': input.index,
-                'create_transaction_id': input.create_transaction_id,
-                'spending_transaction_id': input.spending_transaction_id,
-                'create_output_index': input.create_output_index,
+                'spent_transaction_hash': input.spent_transaction_hash,
+                'spent_output_index': input.spent_output_index,
                 'sequence': input.sequence,
-
                 'script_asm': '', #input.script_asm
                 'script_hex': '', #input.script_hex
-
                 'required_signatures': input.required_signatures,
                 'addresses': input.addresses,
                 'value': input.value,
@@ -81,8 +74,8 @@ class BtcTransactionInputMapper(object):
         for dict in dicts:
             input = BtcTransactionInput()
             input.index = dict.get('index')
-            input.create_transaction_id = dict.get('create_transaction_id')
-            input.create_output_index = dict.get('create_output_index')
+            input.spent_transaction_hash = dict.get('spent_transaction_hash')
+            input.spent_output_index = dict.get('spent_output_index')
             input.script_asm = '' #dict.get('script_asm')
             input.script_hex = '' #dict.get('script_hex')
             input.sequence = dict.get('sequence')
@@ -90,7 +83,6 @@ class BtcTransactionInputMapper(object):
             input.type = dict.get('type')
             input.addresses = dict.get('addresses')
             input.value = dict.get('value')
-            input.spending_transaction_id = dict.get('spending_transaction_id')
 
             result.append(input)
         return result

--- a/bitcoinetl/mappers/transaction_input_mapper.py
+++ b/bitcoinetl/mappers/transaction_input_mapper.py
@@ -74,8 +74,8 @@ class BtcTransactionInputMapper(object):
         for dict in dicts:
             input = BtcTransactionInput()
             input.index = dict.get('index')
-            input.spent_transaction_hash = dict.get('create_transaction_id')
-            input.spent_output_index = dict.get('create_output_index')
+            input.spent_transaction_hash = dict.get('spent_transaction_hash')
+            input.spent_output_index = dict.get('spent_output_index')
             input.script_asm = '' #dict.get('script_asm')
             input.script_hex = '' #dict.get('script_hex')
             input.sequence = dict.get('sequence')

--- a/bitcoinetl/mappers/transaction_input_mapper.py
+++ b/bitcoinetl/mappers/transaction_input_mapper.py
@@ -74,8 +74,8 @@ class BtcTransactionInputMapper(object):
         for dict in dicts:
             input = BtcTransactionInput()
             input.index = dict.get('index')
-            input.spent_transaction_hash = dict.get('spent_transaction_hash')
-            input.spent_output_index = dict.get('spent_output_index')
+            input.spent_transaction_hash = dict.get('create_transaction_id')
+            input.spent_output_index = dict.get('create_output_index')
             input.script_asm = '' #dict.get('script_asm')
             input.script_hex = '' #dict.get('script_hex')
             input.sequence = dict.get('sequence')

--- a/bitcoinetl/mappers/transaction_mapper.py
+++ b/bitcoinetl/mappers/transaction_mapper.py
@@ -61,11 +61,9 @@ class BtcTransactionMapper(object):
 
         transaction.inputs = self.transaction_input_mapper.vin_to_inputs(
             vin=json_dict.get('vin'),
-            spending_transaction_id=transaction.transaction_id
         )
         transaction.outputs = self.transaction_output_mapper.vout_to_outputs(
             vout=json_dict.get('vout'),
-            create_transaction_id=transaction.transaction_id
         )
 
         # Only Zcash

--- a/bitcoinetl/mappers/transaction_mapper.py
+++ b/bitcoinetl/mappers/transaction_mapper.py
@@ -70,6 +70,7 @@ class BtcTransactionMapper(object):
         transaction.value_balance = bitcoin_to_satoshi(json_dict.get('valueBalance'))
 
         # New fields
+        transaction.weight = json_dict.get('weight')
         transaction.output_addresses = self.get_output_addresses(transaction)
         return transaction
 

--- a/bitcoinetl/mappers/transaction_mapper.py
+++ b/bitcoinetl/mappers/transaction_mapper.py
@@ -38,12 +38,11 @@ class BtcTransactionMapper(object):
 
     def json_dict_to_transaction(self, json_dict, block=None, index=None):
         transaction = BtcTransaction()
-        transaction.hash = json_dict.get('hash')
+        transaction.hash = json_dict.get('txid')
         transaction.size = json_dict.get('size')
         transaction.virtual_size = json_dict.get('vsize')
         transaction.version = json_dict.get('version')
         transaction.lock_time = json_dict.get('locktime')
-        transaction.transaction_id = json_dict.get('txid')
 
         if block is not None:
             transaction.block_number = block.number
@@ -70,7 +69,6 @@ class BtcTransactionMapper(object):
         transaction.join_splits = self.join_split_mapper.vjoinsplit_to_join_splits(json_dict.get('vjoinsplit'))
         transaction.value_balance = bitcoin_to_satoshi(json_dict.get('valueBalance'))
 
-        transaction.weight = json_dict.get('weight')
         transaction.output_addresses = self.get_output_addresses(transaction)
         return transaction
 
@@ -81,7 +79,6 @@ class BtcTransactionMapper(object):
         result = {
             'type': 'transaction',
             'hash': transaction.hash,
-            'transaction_id': transaction.transaction_id,
             'size': transaction.size,
             'virtual_size': transaction.virtual_size,
             'version': transaction.version,
@@ -90,7 +87,6 @@ class BtcTransactionMapper(object):
             'block_hash': transaction.block_hash,
             'block_timestamp': transaction.block_timestamp,
             'is_coinbase': transaction.is_coinbase,
-            'index': transaction.index,
 
             'inputs': self.transaction_input_mapper.inputs_to_dicts(transaction.inputs),
             'outputs': self.transaction_output_mapper.outputs_to_dicts(transaction.outputs),
@@ -100,7 +96,6 @@ class BtcTransactionMapper(object):
             'input_value': transaction.calculate_input_value(),
             'output_value': transaction.calculate_output_value(),
             'fee': transaction.calculate_fee(),
-            'weight': transaction.weight,
             'output_addresses': transaction.output_addresses
         }
         return result
@@ -108,7 +103,6 @@ class BtcTransactionMapper(object):
     def dict_to_transaction(self, dict):
         transaction = BtcTransaction()
         transaction.hash = dict.get('hash')
-        transaction.transaction_id = dict.get('transaction_id')
         transaction.size = dict.get('size')
         transaction.virtual_size = dict.get('virtual_size')
         transaction.version = dict.get('version')
@@ -117,8 +111,6 @@ class BtcTransactionMapper(object):
         transaction.block_hash = dict.get('block_hash')
         transaction.block_timestamp = dict.get('block_timestamp')
         transaction.is_coinbase = dict.get('is_coinbase')
-        transaction.index = dict.get('index')
-        transaction.weight = dict.get('weight')
         transaction.output_addresses = dict.get('output_addresses')
         transaction.input_addresses = dict.get('input_addresses')
         transaction.input_count = dict.get('input_count')

--- a/bitcoinetl/mappers/transaction_mapper.py
+++ b/bitcoinetl/mappers/transaction_mapper.py
@@ -70,7 +70,6 @@ class BtcTransactionMapper(object):
         transaction.value_balance = bitcoin_to_satoshi(json_dict.get('valueBalance'))
 
         # New fields
-        transaction.weight = json_dict.get('weight')
         transaction.output_addresses = self.get_output_addresses(transaction)
         return transaction
 
@@ -98,7 +97,6 @@ class BtcTransactionMapper(object):
             'input_value': transaction.calculate_input_value(),
             'output_value': transaction.calculate_output_value(),
             'fee': transaction.calculate_fee(),
-            'weight': transaction.weight,
             'output_addresses': transaction.output_addresses
         }
         return result
@@ -114,7 +112,6 @@ class BtcTransactionMapper(object):
         transaction.block_hash = dict.get('block_hash')
         transaction.block_timestamp = dict.get('block_timestamp')
         transaction.is_coinbase = dict.get('is_coinbase')
-        transaction.weight = dict.get('weight')
         transaction.output_addresses = dict.get('output_addresses')
         transaction.input_addresses = dict.get('input_addresses')
         transaction.input_count = dict.get('input_count')

--- a/bitcoinetl/mappers/transaction_mapper.py
+++ b/bitcoinetl/mappers/transaction_mapper.py
@@ -98,6 +98,7 @@ class BtcTransactionMapper(object):
             'input_value': transaction.calculate_input_value(),
             'output_value': transaction.calculate_output_value(),
             'fee': transaction.calculate_fee(),
+            'weight': transaction.weight,
             'output_addresses': transaction.output_addresses
         }
         return result
@@ -113,6 +114,7 @@ class BtcTransactionMapper(object):
         transaction.block_hash = dict.get('block_hash')
         transaction.block_timestamp = dict.get('block_timestamp')
         transaction.is_coinbase = dict.get('is_coinbase')
+        transaction.weight = dict.get('weight')
         transaction.output_addresses = dict.get('output_addresses')
         transaction.input_addresses = dict.get('input_addresses')
         transaction.input_count = dict.get('input_count')

--- a/bitcoinetl/mappers/transaction_mapper.py
+++ b/bitcoinetl/mappers/transaction_mapper.py
@@ -69,6 +69,8 @@ class BtcTransactionMapper(object):
         transaction.join_splits = self.join_split_mapper.vjoinsplit_to_join_splits(json_dict.get('vjoinsplit'))
         transaction.value_balance = bitcoin_to_satoshi(json_dict.get('valueBalance'))
 
+        # New fields
+        transaction.weight = json_dict.get('weight')
         transaction.output_addresses = self.get_output_addresses(transaction)
         return transaction
 
@@ -96,6 +98,7 @@ class BtcTransactionMapper(object):
             'input_value': transaction.calculate_input_value(),
             'output_value': transaction.calculate_output_value(),
             'fee': transaction.calculate_fee(),
+            'weight': transaction.weight,
             'output_addresses': transaction.output_addresses
         }
         return result
@@ -111,6 +114,7 @@ class BtcTransactionMapper(object):
         transaction.block_hash = dict.get('block_hash')
         transaction.block_timestamp = dict.get('block_timestamp')
         transaction.is_coinbase = dict.get('is_coinbase')
+        transaction.weight = dict.get('weight')
         transaction.output_addresses = dict.get('output_addresses')
         transaction.input_addresses = dict.get('input_addresses')
         transaction.input_count = dict.get('input_count')

--- a/bitcoinetl/mappers/transaction_output_mapper.py
+++ b/bitcoinetl/mappers/transaction_output_mapper.py
@@ -63,20 +63,13 @@ class BtcTransactionOutputMapper(object):
         for output in outputs:
             item = {
                 'index': output.index,
-                'create_transaction_id': output.create_transaction_id,
-                'spending_transaction_id': None,
-
-                'script_asm': '', #output.script_asm
-                'script_hex': '', #output.script_hex
-
+                'script_asm': '', #output.script_asm,
+                'script_hex': '', #output.script_hex,
+                'required_signatures': output.required_signatures,
                 'type': output.type,
                 'addresses': output.addresses,
-                'value': output.value,
-                'required_signatures': output.required_signatures,
+                'value': output.value
             }
-            if output.witness:
-                item['witness'] = output.witness
-
             result.append(item)
         return result
 
@@ -91,9 +84,6 @@ class BtcTransactionOutputMapper(object):
             input.type = dict.get('type')
             input.addresses = dict.get('addresses')
             input.value = dict.get('value')
-            input.witness = dict.get('witness')
-            input.create_transaction_id = dict.get('create_transaction_id')
-            input.spending_transaction_id = dict.get('spending_transaction_id')
 
             result.append(input)
         return result

--- a/bitcoinetl/service/btc_service.py
+++ b/bitcoinetl/service/btc_service.py
@@ -22,6 +22,7 @@
 
 from bitcoinetl.domain.transaction_input import BtcTransactionInput
 from bitcoinetl.domain.transaction_output import BtcTransactionOutput
+from bitcoinetl.enumeration.chain import Chain
 from bitcoinetl.json_rpc_requests import generate_get_block_hash_by_number_json_rpc, \
     generate_get_block_by_hash_json_rpc, generate_get_transaction_by_id_json_rpc
 from bitcoinetl.mappers.block_mapper import BtcBlockMapper

--- a/bitcoinetl/service/btc_service.py
+++ b/bitcoinetl/service/btc_service.py
@@ -22,7 +22,6 @@
 
 from bitcoinetl.domain.transaction_input import BtcTransactionInput
 from bitcoinetl.domain.transaction_output import BtcTransactionOutput
-from bitcoinetl.enumeration.chain import Chain, CoinPriceType
 from bitcoinetl.json_rpc_requests import generate_get_block_hash_by_number_json_rpc, \
     generate_get_block_by_hash_json_rpc, generate_get_transaction_by_id_json_rpc
 from bitcoinetl.mappers.block_mapper import BtcBlockMapper

--- a/bitcoinetl/service/btc_service.py
+++ b/bitcoinetl/service/btc_service.py
@@ -159,7 +159,7 @@ class BtcService(object):
                     block.coinbase_param = coinbase_input.coinbase_param
                     block.coinbase_param_decoded = bytes.fromhex(coinbase_input.coinbase_param).decode('utf-8', 'replace')
                     block.coinbase_tx = transaction
-                    block.coinbase_txid = transaction.transaction_id
+                    block.coinbase_txid = transaction.hash
 
                     block.block_reward = self.get_block_reward(block)
                     transaction.input_count = 0


### PR DESCRIPTION
This PR:
1) Removes fields that are not used by any warehouse. [`create_transaction_id`]
2) Rename field names to match BQ public data and bitcoin-etl 
3) Remove unused imports
